### PR TITLE
Potential fix for #12

### DIFF
--- a/SevenZip/ArchiveOpenCallback.cs
+++ b/SevenZip/ArchiveOpenCallback.cs
@@ -80,6 +80,12 @@ namespace SevenZip
 
         public int GetProperty(ItemPropId propId, ref PropVariant value)
         {
+            if (_fileInfo == null)
+            {
+                // We are likely opening an archive from a Stream, and no file or _fileInfo exists.
+                return 0;
+            }
+
             switch (propId)
             {
                 case ItemPropId.Name:
@@ -111,6 +117,7 @@ namespace SevenZip
                     value.Int64Value = _fileInfo.LastWriteTime.ToFileTime();
                     break;
             }
+
             return 0;
         }
 

--- a/SevenZipTests/SevenZipExtractorTests.cs
+++ b/SevenZipTests/SevenZipExtractorTests.cs
@@ -94,10 +94,11 @@
         [Test]
         public void ExtractionFromStreamTest()
         {
+            // TODO: Rewrite this to test against more/all TestData archives.
+
             using (var tmp = new SevenZipExtractor(File.OpenRead(@"TestData\multiple_files.7z")))
             {
                 tmp.ExtractArchive(OutputDirectory);
-
                 Assert.AreEqual(3, Directory.GetFiles(OutputDirectory).Length);
             }
         }


### PR DESCRIPTION
So the problem seems to be that when we extract from a Stream, there's no file to point to, and therefore no `_fileInfo` object. This crashes `ArchiveOpenCallback.GetProperty(...)`.

I tried replacing `_fileInfo.FullName` with "unknown" if `_fileInfo` was null, which made the operation work fine - but checking the output the extracted files still have their correct names. So just for fun I tried simply exiting the method immediately if no `_fileInfo` is present, and it seems to just work...

I'm admittedly fumbling in the dark here, but this solution seems to work for me.