### PR TITLE
Work in progress: 1810x increase in extraction speed for solid archives.  Fixes #21

### DIFF
--- a/SevenZip/ArchiveExtractCallback.cs
+++ b/SevenZip/ArchiveExtractCallback.cs
@@ -36,6 +36,7 @@ namespace SevenZip
         private OutStreamWrapper _fileStream;
         private bool _directoryStructure;
         private int _currentIndex;
+        private Func<OutStreamWrapper> _getStream;
         const int MEMORY_PRESSURE = 64 * 1024 * 1024; //64mb seems to be the maximum value
 
         #region Constructors
@@ -49,9 +50,10 @@ namespace SevenZip
         /// <param name="extractor">The owner of the callback</param>
         /// <param name="actualIndexes">The list of actual indexes (solid archives support)</param>
         /// <param name="directoryStructure">The value indicating whether to preserve directory structure of extracted files.</param>
-        public ArchiveExtractCallback(IInArchive archive, string directory, int filesCount, bool directoryStructure,
+        public ArchiveExtractCallback(Func<OutStreamWrapper> getStream, IInArchive archive, string directory, int filesCount, bool directoryStructure,
             List<uint> actualIndexes, SevenZipExtractor extractor)
         {
+            this._getStream = getStream;
             Init(archive, directory, filesCount, directoryStructure, actualIndexes, extractor);
         }
 
@@ -65,10 +67,11 @@ namespace SevenZip
         /// <param name="extractor">The owner of the callback</param>
         /// <param name="actualIndexes">The list of actual indexes (solid archives support)</param>
         /// <param name="directoryStructure">The value indicating whether to preserve directory structure of extracted files.</param>
-        public ArchiveExtractCallback(IInArchive archive, string directory, int filesCount, bool directoryStructure,
+        public ArchiveExtractCallback(Func<OutStreamWrapper> getStream, IInArchive archive, string directory, int filesCount, bool directoryStructure,
             List<uint> actualIndexes, string password, SevenZipExtractor extractor)
             : base(password)
         {
+            this._getStream = getStream;
             Init(archive, directory, filesCount, directoryStructure, actualIndexes, extractor);
         }
 
@@ -80,9 +83,10 @@ namespace SevenZip
         /// <param name="filesCount">The archive files count</param>
         /// <param name="fileIndex">The file index for the stream</param>
         /// <param name="extractor">The owner of the callback</param>
-        public ArchiveExtractCallback(IInArchive archive, Stream stream, int filesCount, uint fileIndex,
+        public ArchiveExtractCallback(Func<OutStreamWrapper> getStream, IInArchive archive, Stream stream, int filesCount, uint fileIndex,
                                       SevenZipExtractor extractor)
         {
+            this._getStream = getStream;
             Init(archive, stream, filesCount, fileIndex, extractor);
         }
 
@@ -95,10 +99,11 @@ namespace SevenZip
         /// <param name="fileIndex">The file index for the stream</param>
         /// <param name="password">Password for the archive</param>
         /// <param name="extractor">The owner of the callback</param>
-        public ArchiveExtractCallback(IInArchive archive, Stream stream, int filesCount, uint fileIndex, string password,
+        public ArchiveExtractCallback(Func<OutStreamWrapper> getStream, IInArchive archive, Stream stream, int filesCount, uint fileIndex, string password,
                                       SevenZipExtractor extractor)
             : base(password)
         {
+            this._getStream = getStream;
             Init(archive, stream, filesCount, fileIndex, extractor);
         }
 
@@ -130,7 +135,7 @@ namespace SevenZip
             _fakeStream = new FakeOutStreamWrapper();
             _fakeStream.BytesWritten += IntEventArgsHandler;
             _extractor = extractor;
-            GC.AddMemoryPressure(MEMORY_PRESSURE);
+            //GC.AddMemoryPressure(MEMORY_PRESSURE);
         }
         #endregion
 
@@ -382,14 +387,21 @@ namespace SevenZip
                 {
                     #region Extraction to a stream
 
-                    if (index == _fileIndex)
+                    if (_getStream == null)
                     {
-                        outStream = _fileStream;
-                        _fileIndex = null;
+                        if (index == _fileIndex)
+                        {
+                            outStream = _fileStream;
+                            _fileIndex = null;
+                        }
+                        else
+                        {
+                            outStream = _fakeStream;
+                        }
                     }
                     else
                     {
-                        outStream = _fakeStream;
+                        outStream = _getStream();
                     }
 
                     #endregion
@@ -458,8 +470,8 @@ namespace SevenZip
                     }
                     catch (ObjectDisposedException) { }
                     _fileStream = null;
-                    GC.Collect();
-                    GC.WaitForPendingFinalizers();
+                    //GC.Collect();
+                    //GC.WaitForPendingFinalizers();
                 }
                 var iea = new FileInfoEventArgs(
                     _extractor.ArchiveFileData[_currentIndex], PercentDoneEventArgs.ProducePercentDone(_doneRate));                
@@ -492,7 +504,7 @@ namespace SevenZip
 
         public void Dispose()
         {
-            GC.RemoveMemoryPressure(MEMORY_PRESSURE);
+            //GC.RemoveMemoryPressure(MEMORY_PRESSURE);
 
             if (_fileStream != null)
             {

--- a/SevenZip/ArchiveOpenCallback.cs
+++ b/SevenZip/ArchiveOpenCallback.cs
@@ -187,7 +187,7 @@ namespace SevenZip
                 _wrappers = null;
             }
 
-            GC.SuppressFinalize(this);
+            //GC.SuppressFinalize(this);
         }
 
         #endregion        

--- a/SevenZip/ArchiveUpdateCallback.cs
+++ b/SevenZip/ArchiveUpdateCallback.cs
@@ -265,7 +265,7 @@ namespace SevenZip
             set
             {
                 _memoryPressure = (int)(value * 1024 * 1024);
-                GC.AddMemoryPressure(_memoryPressure);
+                //GC.AddMemoryPressure(_memoryPressure);
             }
         }
 
@@ -707,7 +707,7 @@ namespace SevenZip
                         _wrappersToDispose.Add(_fileStream);
                     }                                
                 _fileStream = null;
-                GC.Collect();
+                //GC.Collect();
                 // Issue #6987
                 //GC.WaitForPendingFinalizers();
             }
@@ -731,7 +731,7 @@ namespace SevenZip
 
         public void Dispose()
         {
-            GC.RemoveMemoryPressure(_memoryPressure);
+            //GC.RemoveMemoryPressure(_memoryPressure);
 
             if (_fileStream != null)
             {
@@ -754,7 +754,7 @@ namespace SevenZip
                 }
             }
 
-            GC.SuppressFinalize(this);
+            //GC.SuppressFinalize(this);
         }
 
         #endregion

--- a/SevenZip/Common.cs
+++ b/SevenZip/Common.cs
@@ -64,7 +64,7 @@ namespace SevenZip
         {
             Context = null;
             NeedsToBeRecreated = true;
-            GC.SuppressFinalize(this);
+            //GC.SuppressFinalize(this);
         }
 
         private delegate void EventHandlerDelegate<T>(EventHandler<T> handler, T e) where T : EventArgs;

--- a/SevenZip/SevenZip.csproj
+++ b/SevenZip/SevenZip.csproj
@@ -75,6 +75,9 @@
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/SevenZip/SevenZipExtractorAsynchronous.cs
+++ b/SevenZip/SevenZipExtractorAsynchronous.cs
@@ -93,6 +93,7 @@
         /// </summary>
         /// <param name="extractFileCallback">The callback to call for each file in the archive.</param>
         private delegate void ExtractFiles3Delegate(ExtractFileCallback extractFileCallback);
+        private delegate void ExtractFiles4Delegate(ExtractFileCallback extractFileCallback, Func<OutStreamWrapper> getStream, Action<FileInfoEventArgs> FileExtractStart, Action<FileInfoEventArgs> FileExtractComplete);
         #endregion
 
         /// <summary>
@@ -155,10 +156,10 @@
         /// 7-Zip (and any other solid) archives are NOT supported.
         /// </summary>
         /// <param name="extractFileCallback">The callback to call for each file in the archive.</param>
-        public void BeginExtractFiles(ExtractFileCallback extractFileCallback)
+        public void BeginExtractFiles(ExtractFileCallback extractFileCallback, Func<OutStreamWrapper> getStream = null, Action<FileInfoEventArgs> FileExtractStart = null, Action<FileInfoEventArgs> FileExtractComplete = null)
         {
             SaveContext();
-            new ExtractFiles3Delegate(ExtractFiles).BeginInvoke(extractFileCallback, AsyncCallbackImplementation, this);
+            new ExtractFiles4Delegate(ExtractFiles).BeginInvoke(extractFileCallback, getStream, FileExtractStart, FileExtractComplete, AsyncCallbackImplementation, this);
         }
     }
 }

--- a/SevenZip/StreamWrappers.cs
+++ b/SevenZip/StreamWrappers.cs
@@ -11,7 +11,7 @@ namespace SevenZip
     /// <summary>
     /// A class that has DisposeStream property.
     /// </summary>
-    internal class DisposeVariableWrapper
+    public class DisposeVariableWrapper
     {
         public bool DisposeStream { protected get; set; }
 
@@ -21,7 +21,7 @@ namespace SevenZip
     /// <summary>
     /// Stream wrapper used in InStreamWrapper
     /// </summary>
-    internal class StreamWrapper : DisposeVariableWrapper, IDisposable
+    public class StreamWrapper : DisposeVariableWrapper, IDisposable
     {
         /// <summary>
         /// File name associated with the stream (for date fix)
@@ -94,7 +94,7 @@ namespace SevenZip
                 catch (ArgumentOutOfRangeException) {}
             }
 
-            GC.SuppressFinalize(this);
+            //GC.SuppressFinalize(this);
         }
 
         #endregion
@@ -162,7 +162,7 @@ namespace SevenZip
     /// <summary>
     /// IOutStream wrapper used in stream write operations.
     /// </summary>
-    internal sealed class OutStreamWrapper : StreamWrapper, ISequentialOutStream, IOutStream
+    public sealed class OutStreamWrapper : StreamWrapper, ISequentialOutStream, IOutStream
     {
         /// <summary>
         /// Initializes a new instance of the OutStreamWrapper class
@@ -268,7 +268,7 @@ namespace SevenZip
                 }
                 Streams.Clear();
             }
-            GC.SuppressFinalize(this);
+            //GC.SuppressFinalize(this);
         }
 
         #endregion
@@ -459,7 +459,7 @@ namespace SevenZip
 
         public void Dispose()
         {
-            GC.SuppressFinalize(this);
+            //GC.SuppressFinalize(this);
         }
 
         #endregion


### PR DESCRIPTION
brought a direct stream getter delegate out
made the stream classes public
changed the signature for the "extract all files with callback" function
removed garbage collection bossiness