### PR TITLE
LibraryManager: Check if Assembly.Location is empty/null before use

### DIFF
--- a/SevenZip/LibraryManager.cs
+++ b/SevenZip/LibraryManager.cs
@@ -39,7 +39,8 @@ namespace SevenZip
             {
                 return ConfigurationManager.AppSettings["7zLocation"];
             }
-
+	
+            if (string.IsNullOrEmpty(Assembly.GetExecutingAssembly().Location)) return null;
             return Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), Environment.Is64BitProcess ? "7z64.dll" : "7z.dll");
         }
 

--- a/SevenZip/LibraryManager.cs
+++ b/SevenZip/LibraryManager.cs
@@ -40,7 +40,11 @@ namespace SevenZip
                 return ConfigurationManager.AppSettings["7zLocation"];
             }
 	
-            if (string.IsNullOrEmpty(Assembly.GetExecutingAssembly().Location)) return null;
+            if (string.IsNullOrEmpty(Assembly.GetExecutingAssembly().Location)) 
+	    {
+		return null;
+	    }
+
             return Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), Environment.Is64BitProcess ? "7z64.dll" : "7z.dll");
         }
 


### PR DESCRIPTION
I am trying to use this library to do some 7z and LZMA stuff. I have been setting it up and am setting the location of the 7z.dll through SevenZip.SevenZipBase.SetLibraryPath(). However, when I call this method, an exception is thrown in the library.

I added the source to my project and have traced it to the DetermineLibraryFilePath() method, which is being called when the _libraryFileName variable is initialized statically for the class.

![image](https://user-images.githubusercontent.com/2738836/65101887-b5c5e080-d986-11e9-8ed3-0ec144a2f8d2.png)

I am not 100% sure of why the .Location attribute of the executing assembly would be null (I am not well versed enough to know why it would do this). I am fairly certain this has to do with using the library with Fody.Weavers and Costura.Fody. I am using these nuget packages to allow my application to embed it's dll's into the executable by weaving the IL (I am not embedding 7z.dll, it is external). It has reliably worked for my other DLLs, but for this one it has not.

In this PR, I check if Location is null before attempting to call anything on it. If it is null/empty, I simply return null, since we won't have the path anyways. In my code, this worked just fine. This is part of my work for Mass Effect Mod Manager (https://github.com/ME3Tweaks/MassEffectModManager).

In the event this occurs, the user would have to set the library path manually. I am not sure what a more reasonable default might be.