### PR TITLE
Fixed issue related to invalid character in directory and file name.

### DIFF
--- a/SevenZip/ArchiveExtractCallback.cs
+++ b/SevenZip/ArchiveExtractCallback.cs
@@ -292,18 +292,19 @@ namespace SevenZip
                         }
 
                         #endregion
-
-                        fileName = Path.Combine(_directory, _directoryStructure? entryName : Path.GetFileName(entryName));
-                        _archive.GetProperty(index, ItemPropId.IsDirectory, ref data);
+                        
                         try
                         {
-                            fileName = ValidateFileName(fileName);
+                            fileName = Path.Combine(RemoveIllegalCharacters(_directory, true), RemoveIllegalCharacters(_directoryStructure ? entryName : Path.GetFileName(entryName)));
+                            ValidateFileNameAndCreateDirectory(fileName);
                         }
                         catch (Exception e)
                         {
                             AddException(e);
                             goto FileExtractionStartedLabel;
                         }
+
+                        _archive.GetProperty(index, ItemPropId.IsDirectory, ref data);
                         if (!NativeMethods.SafeCast(data, false))
                         {
                             #region Branch
@@ -521,7 +522,7 @@ namespace SevenZip
         /// </summary>
         /// <param name="fileName">File name</param>
         /// <returns>The valid file name</returns>
-        private static string ValidateFileName(string fileName)
+        private static void ValidateFileNameAndCreateDirectory(string fileName)
         {
             if (String.IsNullOrEmpty(fileName))
             {
@@ -530,11 +531,35 @@ namespace SevenZip
 
             var splittedFileName = new List<string>(fileName.Split(Path.DirectorySeparatorChar));
 
+            if (splittedFileName.Count > 2)
+            {
+                string tfn = splittedFileName[0];
+                for (int i = 1; i < splittedFileName.Count - 1; i++)
+                {
+                    tfn += Path.DirectorySeparatorChar + splittedFileName[i];
+                    if (!Directory.Exists(tfn))
+                    {
+                        Directory.CreateDirectory(tfn);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// removes the invalid character in file path.
+        /// </summary>
+        /// <param name="str"></param>
+        /// <param name="isDirectory"></param>
+        /// <returns></returns>
+        private static string RemoveIllegalCharacters(string str, bool isDirectory = false)
+        {
+            var splittedFileName = new List<string>(str.Split(Path.DirectorySeparatorChar));
+
             foreach (char chr in Path.GetInvalidFileNameChars())
             {
                 for (int i = 0; i < splittedFileName.Count; i++)
                 {
-                    if (chr == ':' && i == 0)
+                    if (isDirectory && chr == ':' && i == 0)
                     {
                         continue;
                     }
@@ -549,25 +574,12 @@ namespace SevenZip
                 }
             }
 
-            if (fileName.StartsWith(new string(Path.DirectorySeparatorChar, 2),
+            if (str.StartsWith(new string(Path.DirectorySeparatorChar, 2),
                                     StringComparison.CurrentCultureIgnoreCase))
             {
                 splittedFileName.RemoveAt(0);
                 splittedFileName.RemoveAt(0);
                 splittedFileName[0] = new string(Path.DirectorySeparatorChar, 2) + splittedFileName[0];
-            }
-
-            if (splittedFileName.Count > 2)
-            {
-                string tfn = splittedFileName[0];
-                for (int i = 1; i < splittedFileName.Count - 1; i++)
-                {
-                    tfn += Path.DirectorySeparatorChar + splittedFileName[i];
-                    if (!Directory.Exists(tfn))
-                    {
-                        Directory.CreateDirectory(tfn);
-                    }
-                }
             }
 
             return String.Join(new string(Path.DirectorySeparatorChar, 1), splittedFileName.ToArray());


### PR DESCRIPTION
I have some issue related to invalid character in file name while extracting dmg file of [TeamViewer.](https://dl5.filehippo.com/107/123/463bc4cbe49c4c0614ee730a536372153d/TeamViewer.dmg?Expires=1570217798&Signature=e88044a84f85ea0f0adbdec0633f22c196688170&channel=WEB&id_file=8fc01086-9b27-11e6-8072-00163ec9f5fa&instance=filehippo_en&type=PROGRAM&url=https://filehippo.com/mac/download_teamviewer_for_mac/&Filename=TeamViewer.dmg) 

I have fix the issue. Please verify and merge it.