### PR TITLE
Support SFN paths when compressing directories

### DIFF
--- a/SevenZip.Tests/SevenZip.Tests.csproj
+++ b/SevenZip.Tests/SevenZip.Tests.csproj
@@ -68,6 +68,9 @@
     <None Include="TestData\zip.zip">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="TestData_LongerDirectoryName\emptyfile.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SevenZip\SevenZip.csproj" />

--- a/SevenZip.Tests/SevenZipCompressorTests.cs
+++ b/SevenZip.Tests/SevenZipCompressorTests.cs
@@ -39,12 +39,12 @@
                 PreserveDirectoryRoot = true
             };
 
-
             compressor.CompressDirectory("TESTDA~1", TemporaryFile);
             Assert.IsTrue(File.Exists(TemporaryFile));
 
             using (var extractor = new SevenZipExtractor(TemporaryFile))
             {
+                Assert.AreEqual(1, extractor.FilesCount);
                 Assert.IsTrue(extractor.ArchiveFileNames[0].StartsWith("TestData_LongerDirectoryName", StringComparison.OrdinalIgnoreCase));
             }
         }
@@ -56,6 +56,24 @@
 
             Assert.Throws<ArgumentException>(() => compressor.CompressDirectory("nonexistent", TemporaryFile));
             Assert.Throws<ArgumentException>(() => compressor.CompressDirectory("", TemporaryFile));
+        }
+
+        [Test]
+        public void CompressFile_WithSfnPath()
+        {
+            var compressor = new SevenZipCompressor
+            {
+                ArchiveFormat = OutArchiveFormat.Zip
+            };
+
+            compressor.CompressFiles(TemporaryFile, @"TESTDA~1\emptyfile.txt");
+            Assert.IsTrue(File.Exists(TemporaryFile));
+
+            using (var extractor = new SevenZipExtractor(TemporaryFile))
+            {
+                Assert.AreEqual(1, extractor.FilesCount);
+                Assert.AreEqual("emptyfile.txt", extractor.ArchiveFileNames[0]);
+            }
         }
 
         [Test]

--- a/SevenZip.Tests/SevenZipCompressorTests.cs
+++ b/SevenZip.Tests/SevenZipCompressorTests.cs
@@ -31,6 +31,34 @@
         }
 
         [Test]
+        public void CompressDirectory_WithSfnPath()
+        {
+            var compressor = new SevenZipCompressor
+            {
+                ArchiveFormat = OutArchiveFormat.Zip,
+                PreserveDirectoryRoot = true
+            };
+
+
+            compressor.CompressDirectory("TESTDA~1", TemporaryFile);
+            Assert.IsTrue(File.Exists(TemporaryFile));
+
+            using (var extractor = new SevenZipExtractor(TemporaryFile))
+            {
+                Assert.IsTrue(extractor.ArchiveFileNames[0].StartsWith("TestData_LongerDirectoryName", StringComparison.OrdinalIgnoreCase));
+            }
+        }
+
+        [Test]
+        public void CompressDirectory_NonExistentDirectory()
+        {
+            var compressor = new SevenZipCompressor();
+
+            Assert.Throws<ArgumentException>(() => compressor.CompressDirectory("nonexistent", TemporaryFile));
+            Assert.Throws<ArgumentException>(() => compressor.CompressDirectory("", TemporaryFile));
+        }
+
+        [Test]
         public void CompressFileTest()
         {
             var compressor = new SevenZipCompressor

--- a/SevenZip/SevenZipCompressor.cs
+++ b/SevenZip/SevenZipCompressor.cs
@@ -1356,6 +1356,9 @@ namespace SevenZip
                 throw new ArgumentException("Directory \"" + directory + "\" does not exist!");
             }
 
+            // Get full path, in case this is eg. an SFN path.
+            directory = Path.GetFullPath(directory);
+
             if (RecursiveDirectoryEmptyCheck(directory))
             {
                 throw new SevenZipInvalidFileNamesException("the specified directory is empty!");

--- a/SevenZip/SevenZipCompressor.cs
+++ b/SevenZip/SevenZipCompressor.cs
@@ -486,6 +486,7 @@ namespace SevenZip
         private static int CommonRoot(ICollection<string> files)
         {
             var splitFileNames = new List<string[]>(files.Count);
+
             splitFileNames.AddRange(files.Select(fn => fn.Split(Path.DirectorySeparatorChar)));
             var minSplitLength = splitFileNames[0].Length - 1;
 
@@ -1106,7 +1107,7 @@ namespace SevenZip
         public void CompressFiles(
             string archiveName, params string[] fileFullNames)
         {
-            CompressFilesEncrypted(archiveName, "", fileFullNames);
+            CompressFilesEncrypted(archiveName, string.Empty, fileFullNames);
         }
 
         /// <summary>
@@ -1118,7 +1119,7 @@ namespace SevenZip
         public void CompressFiles(
             Stream archiveStream, params string[] fileFullNames)
         {
-            CompressFilesEncrypted(archiveStream, "", fileFullNames);
+            CompressFilesEncrypted(archiveStream, string.Empty, fileFullNames);
         }
 
         /// <summary>
@@ -1130,7 +1131,7 @@ namespace SevenZip
         public void CompressFiles(
             string archiveName, int commonRootLength, params string[] fileFullNames)
         {
-            CompressFilesEncrypted(archiveName, commonRootLength, "", fileFullNames);
+            CompressFilesEncrypted(archiveName, commonRootLength, string.Empty, fileFullNames);
         }
 
         /// <summary>
@@ -1143,7 +1144,8 @@ namespace SevenZip
         public void CompressFiles(
             Stream archiveStream, int commonRootLength, params string[] fileFullNames)
         {
-            CompressFilesEncrypted(archiveStream, commonRootLength, "", fileFullNames);
+            fileFullNames = GetFullFilePaths(fileFullNames);
+            CompressFilesEncrypted(archiveStream, commonRootLength, string.Empty, fileFullNames);
         }
 
         /// <summary>
@@ -1155,6 +1157,7 @@ namespace SevenZip
         public void CompressFilesEncrypted(
             string archiveName, string password, params string[] fileFullNames)
         {
+            fileFullNames = GetFullFilePaths(fileFullNames);
             CompressFilesEncrypted(archiveName, CommonRoot(fileFullNames), password, fileFullNames);
         }
 
@@ -1168,6 +1171,7 @@ namespace SevenZip
         public void CompressFilesEncrypted(
             Stream archiveStream, string password, params string[] fileFullNames)
         {
+            fileFullNames = GetFullFilePaths(fileFullNames);
             CompressFilesEncrypted(archiveStream, CommonRoot(fileFullNames), password, fileFullNames);
         }
 
@@ -1868,6 +1872,16 @@ namespace SevenZip
                     return outStream.ToArray();
                 }
             }
+        }
+
+        /// <summary>
+        /// Ensures an array of file names is the full path to that file.
+        /// </summary>
+        /// <param name="fileFullNames">Array of file names.</param>
+        /// <returns>Array of file names with full paths.</returns>
+        private static string[] GetFullFilePaths(IEnumerable<string> fileFullNames)
+        {
+            return fileFullNames.Select(Path.GetFullPath).ToArray();
         }
     }
 }


### PR DESCRIPTION
The problem lies in how SevenZipSharp tries to determine the common root of files, to determine the directory structure within the archive. 

The SFN path messes this up, and the simplest solution is to simply ensure we always have the full path to the files we're compressing.

Fixes #102