### PR TITLE
Get path to 7z.dll lazily

### DIFF
--- a/SevenZip/LibraryManager.cs
+++ b/SevenZip/LibraryManager.cs
@@ -31,7 +31,7 @@ namespace SevenZip
         ///     - Built decoders: LZMA, PPMD, BCJ, BCJ2, COPY, AES-256 Encryption, BZip2, Deflate.
         /// 7z.dll (from the 7-zip distribution) supports every InArchiveFormat for encoding and decoding.
         /// </remarks>
-        private static string _libraryFileName = DetermineLibraryFilePath();
+        private static string _libraryFileName;
 
         private static string DetermineLibraryFilePath()
         {
@@ -41,9 +41,9 @@ namespace SevenZip
             }
 	
             if (string.IsNullOrEmpty(Assembly.GetExecutingAssembly().Location)) 
-	    {
-		return null;
-	    }
+            {
+                return null;
+            }
 
             return Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), Environment.Is64BitProcess ? "7z64.dll" : "7z.dll");
         }
@@ -115,6 +115,11 @@ namespace SevenZip
 
                 if (_modulePtr == IntPtr.Zero)
                 {
+                    if (_libraryFileName == null)
+                    {
+                        _libraryFileName = DetermineLibraryFilePath();
+                    }
+
                     if (!File.Exists(_libraryFileName))
                     {
                         throw new SevenZipLibraryException("DLL file does not exist.");
@@ -158,6 +163,11 @@ namespace SevenZip
                 {
                     if (!_modifyCapable.HasValue)
                     {
+                        if (_libraryFileName == null)
+                        {
+                            _libraryFileName = DetermineLibraryFilePath();
+                        }
+
                         FileVersionInfo dllVersionInfo = FileVersionInfo.GetVersionInfo(_libraryFileName);
                         _modifyCapable = dllVersionInfo.FileMajorPart >= 9;
                     }


### PR DESCRIPTION
Hello,

I'm using SevenZipSharp in a PowerShell Cmdlet. However, after switching my lib to .NET Standard, a user [reported](https://github.com/thoemmi/7Zip4Powershell/issues/70) that the library now throws a `TypeInitializationException`:
![Screenshot](https://user-images.githubusercontent.com/16168755/99407812-d0c81380-28ef-11eb-93b9-8e9af0929c54.png)

Some research revealed that there might be a correlation between using `ConfigurationManager` and PowerShell. See [Operation not supported in this platform creating an NHibernate Configuration from powershell](https://stackoverflow.com/questions/60487175/operation-not-supported-in-this-platform-creating-an-nhibernate-configuration-fr) for reference.

In my code I do call `SevenZipBase.SetLibraryPath` explicitly. However, `DetermineLibraryFilePath()` is called during type initialization even if it's not required.

With this PR the library path is evaluated lazily, i.e. only if it's not set explicitly (using `SetLibraryPath`), `DetermineLibraryFilePath()` will be called.