### PR TITLE
Update SIGNATURE_SIZE constant from 16 bytes to 21 bytes to support DEB signature length

### DIFF
--- a/SevenZip/FileChecker.cs
+++ b/SevenZip/FileChecker.cs
@@ -10,7 +10,7 @@
     /// <remarks>Based on the code at http://blog.somecreativity.com/2008/04/08/how-to-check-if-a-file-is-compressed-in-c/#</remarks>
     internal static class FileChecker
     {
-        private const int SIGNATURE_SIZE = 16;
+        private const int SIGNATURE_SIZE = 21;
         private const int SFX_SCAN_LENGTH = 256 * 1024;
 
         private static bool SpecialDetect(Stream stream, int offset, InArchiveFormat expectedFormat)


### PR DESCRIPTION
`InArchiveFormat.Deb` is declared as `"21-3C-61-72-63-68-3E-0A-64-65-62-69-61-6E-2D-62-69-6E-61-72-79"`, which requires 21 bytes to match, rather than the 16 currently supported in `SpecialDetect()`

This PR simply increases the `SIGNATURE_SIZE` constant from `16` to `21`