### PR TITLE
Implement 'Skip' option in FileExtractionStarted event

### DIFF
--- a/SevenZip.Tests/SevenZipExtractorTests.cs
+++ b/SevenZip.Tests/SevenZipExtractorTests.cs
@@ -93,6 +93,24 @@
         }
 
         [Test]
+        public void ExtractionWithSkipTest()
+        {
+            using (var tmp = new SevenZipExtractor(@"TestData\multiple_files.7z"))
+            {
+                tmp.FileExtractionStarted += (s, e) =>
+                                             {
+                                                 if (e.FileInfo.Index == 3)
+                                                 {
+                                                     e.Skip = true;
+                                                 }
+                                             };
+
+                tmp.ExtractArchive(OutputDirectory);
+
+                Assert.AreEqual(2, Directory.GetFiles(OutputDirectory).Length);
+            }
+        }
+        [Test]
         public void ExtractionFromStreamTest()
         {
             // TODO: Rewrite this to test against more/all TestData archives.

--- a/SevenZip.Tests/SevenZipExtractorTests.cs
+++ b/SevenZip.Tests/SevenZipExtractorTests.cs
@@ -99,7 +99,7 @@
             {
                 tmp.FileExtractionStarted += (s, e) =>
                                              {
-                                                 if (e.FileInfo.Index == 3)
+                                                 if (e.FileInfo.Index == 1)
                                                  {
                                                      e.Skip = true;
                                                  }

--- a/SevenZip/EventArguments/FileInfoEventArgs.cs
+++ b/SevenZip/EventArguments/FileInfoEventArgs.cs
@@ -24,6 +24,11 @@
         public bool Cancel { get; set; }
 
         /// <summary>
+        /// Gets or sets whether to skip the current file.
+        /// </summary>
+        public bool Skip { get; set; }
+
+        /// <summary>
         /// Gets the corresponding FileInfo to the event.
         /// </summary>
         public ArchiveFileInfo FileInfo => _fileInfo;

--- a/SevenZip/EventArguments/FileNameEventArgs.cs
+++ b/SevenZip/EventArguments/FileNameEventArgs.cs
@@ -1,4 +1,6 @@
-﻿#if UNMANAGED
+﻿using System;
+
+#if UNMANAGED
 
 namespace SevenZip
 {
@@ -25,6 +27,14 @@ namespace SevenZip
         /// </summary>
         public bool Cancel { get; set; }
 
+        /// <summary>
+        /// Gets or sets whether to stop the current archive operation.
+        /// </summary>
+        public bool Skip
+        {
+            get => false;
+            set => throw new NotImplementedException();
+        }
         /// <summary>
         /// Gets the file name.
         /// </summary>

--- a/SevenZip/EventArguments/ICancellable.cs
+++ b/SevenZip/EventArguments/ICancellable.cs
@@ -9,5 +9,10 @@
         /// Gets or sets whether to stop the current archive operation.
         /// </summary>
         bool Cancel { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to skip the current file.
+        /// </summary>
+        bool Skip { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds the ability to skip extraction of a single file in the 'FileExtractionStarted' event.  Setting the `Skip` parameter to `TRUE` in `FileInfoEventArgs` will cause the extractor to ignore the current file and proceed with the next one.

It was also necessary to restructure the code flow in `ArchiveExtractCallback`, and separate `ValidateFileNameAndCreateDirectory()` into two separate methods (`ValidateFileName()` and `CreateDirectory()`) in order to ensure that empty directories were not created when using the 'Skip'  feature to elide whole directory trees