### PR TITLE
fixed warning "There are some data after the end of the payload data" with multi volume archives

### DIFF
--- a/SevenZip/StreamWrappers.cs
+++ b/SevenZip/StreamWrappers.cs
@@ -415,7 +415,7 @@ namespace SevenZip
             int offset = 0;
             var originalSize = (int) size;
             Position += size;
-            _overallLength = Math.Max(Position + 1, _overallLength);
+            _overallLength = Math.Max(Position, _overallLength);
             while (size > _volumeSize - Streams[CurrentStream].Position)
             {
                 var count = (int) (_volumeSize - Streams[CurrentStream].Position);


### PR DESCRIPTION
fix for issue #145