### PR TITLE
Code changes to fix append operation for archives with encrypted header

### DIFF
--- a/SevenZip/SevenZipCompressor.cs
+++ b/SevenZip/SevenZipCompressor.cs
@@ -1202,6 +1202,8 @@ namespace SevenZip
                     return;
                 }
             }
+            
+            UpdateCompressorPassword(password);
 
             if (_volumeSize == 0 || !_compressingFilesOnDisk)
             {
@@ -1499,7 +1501,9 @@ namespace SevenZip
             {
                 ValidateStream(archiveStream);
             }
-
+            
+            UpdateCompressorPassword(password);
+            
             if (streamDictionary.Where(
                 pair => pair.Value != null && (!pair.Value.CanSeek || !pair.Value.CanRead)).Any(
                 pair => !ThrowException(null,
@@ -1664,11 +1668,7 @@ namespace SevenZip
                 }
             }
 
-            if (!string.IsNullOrEmpty(password) && string.IsNullOrEmpty(Password))
-            {
-                // When modifying an encrypted archive, Password is not set in the SevenZipCompressor.
-                Password = password;
-            }
+            UpdateCompressorPassword(password);
 
             try
             {
@@ -1861,6 +1861,19 @@ namespace SevenZip
         private static string[] GetFullFilePaths(IEnumerable<string> fileFullNames)
         {
             return fileFullNames.Select(Path.GetFullPath).ToArray();
+        }
+        
+        /// <summary>
+        /// Check and update password in SevenZipCompressor
+        /// </summary>
+        /// <param name="password"></param>
+        private void UpdateCompressorPassword(string password)
+        {
+            if (!string.IsNullOrEmpty(password) && string.IsNullOrEmpty(Password))
+            {
+                // When modifying an encrypted archive, Password is not set in the SevenZipCompressor.
+                Password = password;
+            }
         }
     }
 }

--- a/SevenZip/SevenZipCompressor.cs
+++ b/SevenZip/SevenZipCompressor.cs
@@ -1866,7 +1866,7 @@ namespace SevenZip
         /// <summary>
         /// Check and update password in SevenZipCompressor
         /// </summary>
-        /// <param name="password"></param>
+        /// <param name="password">The password to use.</param>
         private void UpdateCompressorPassword(string password)
         {
             if (!string.IsNullOrEmpty(password) && string.IsNullOrEmpty(Password))


### PR DESCRIPTION
Fix for issue: https://github.com/squid-box/SevenZipSharp/issues/153. 
Code changes to update Password in SevenZipCompressor for append operations on encrypted archives. 
This fix is based on code changes done under: https://github.com/squid-box/SevenZipSharp/pull/20