### PR TITLE
Calculate UniqueID via increment

### DIFF
--- a/SevenZip/SevenZipBase.cs
+++ b/SevenZip/SevenZipBase.cs
@@ -15,7 +15,7 @@ namespace SevenZip
     {
         private readonly bool _reportErrors;
         private readonly int _uniqueID;
-        private static readonly List<int> Identifiers = new List<int>();
+        private static int _incrementingUniqueId = int.MinValue;
 
         /// <summary>
         /// True if the instance of the class needs to be recreated in new thread context; otherwise, false.
@@ -103,22 +103,8 @@ namespace SevenZip
 
         private static int GetUniqueID()
         {
-            lock (Identifiers)
-            {
-                int id;
-
-                var rnd = new Random(DateTime.Now.Millisecond);
-
-                do
-                {
-                    id = rnd.Next(int.MaxValue);
-                }
-                while (Identifiers.Contains(id));
-
-                Identifiers.Add(id);
-
-                return id;
-            }
+            var newUniqueId = Interlocked.Increment(ref _incrementingUniqueId);
+            return newUniqueId;
         }
 
         /// <summary>
@@ -130,18 +116,6 @@ namespace SevenZip
             Password = password;
             _reportErrors = true;
             _uniqueID = GetUniqueID();
-        }
-
-        /// <summary>
-        /// Removes the UniqueID from the list.
-        /// </summary>
-        ~SevenZipBase()
-        {
-            // This lock probably isn't necessary but just in case...
-            lock (Identifiers)
-            {
-                Identifiers.Remove(_uniqueID);
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
Instead of trying to find unique id randomly, which is costly, do it sequentially instead.
In this case, we have ~4 billion unique identifiers, and even if we exhaust them all, we will reset back to `int.MinValue` and start over.
It also helps getting rid of locking in the finalizer.

Fixes #162 