### PR TITLE
Fixed bug in asynchronous extraction calls

### DIFF
--- a/SevenZip.Tests/SevenZip.Tests.csproj
+++ b/SevenZip.Tests/SevenZip.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <AssemblyTitle>SevenZip.Tests</AssemblyTitle>
     <Product>SevenZipTests</Product>
     <Copyright>Copyright © Joel Ahlgren 2023</Copyright>

--- a/SevenZip.Tests/SevenZip.Tests.csproj
+++ b/SevenZip.Tests/SevenZip.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <AssemblyTitle>SevenZip.Tests</AssemblyTitle>
     <Product>SevenZipTests</Product>
     <Copyright>Copyright © Joel Ahlgren 2023</Copyright>

--- a/SevenZip.Tests/SevenZipCompressorTests.cs
+++ b/SevenZip.Tests/SevenZipCompressorTests.cs
@@ -381,24 +381,26 @@
         [Test]
         public void AppendEncryptedFileToStreamTest()
         {
-            using var fileStream = new FileStream(TemporaryFile, FileMode.Create);
-
-            var compressor = new SevenZipCompressor
+            using (var fileStream = new FileStream(TemporaryFile, FileMode.Create))
             {
-                ArchiveFormat = OutArchiveFormat.SevenZip,
-                CompressionMethod = CompressionMethod.Lzma2,
-                CompressionMode = CompressionMode.Append,
-                ZipEncryptionMethod = ZipEncryptionMethod.Aes256,
-                CompressionLevel = CompressionLevel.Normal,
-                EncryptHeaders = true
-            };
+                var compressor = new SevenZipCompressor
+                {
+                    ArchiveFormat = OutArchiveFormat.SevenZip,
+                    CompressionMethod = CompressionMethod.Lzma2,
+                    CompressionMode = CompressionMode.Append,
+                    ZipEncryptionMethod = ZipEncryptionMethod.Aes256,
+                    CompressionLevel = CompressionLevel.Normal,
+                    EncryptHeaders = true
+                };
 
-            compressor.CompressFilesEncrypted(fileStream, "password", @"TestData\zip.zip");
+                compressor.CompressFilesEncrypted(fileStream, "password", @"TestData\zip.zip");
+            }
 
-            using var extractor = new SevenZipExtractor(TemporaryFile, "password");
-
-            Assert.AreEqual(1, extractor.FilesCount);
-            Assert.AreEqual("zip.zip", extractor.ArchiveFileNames[0]);
+            using (var extractor = new SevenZipExtractor(TemporaryFile, "password"))
+            {
+                Assert.AreEqual(1, extractor.FilesCount);
+                Assert.AreEqual("zip.zip", extractor.ArchiveFileNames[0]);
+            }
         }
     }
 }

--- a/SevenZip.Tests/SevenZipExtractorAsynchronousTests.cs
+++ b/SevenZip.Tests/SevenZipExtractorAsynchronousTests.cs
@@ -79,7 +79,7 @@
                     extractor.ExtractionFinished += (o, e) => extractionFinishedInvoked = true;
                     extractor.BeginExtractFile(0, fileStream);
 
-                    var maximumTimeToWait = 500;
+                    var maximumTimeToWait = 2000;
 
                     while (!extractionFinishedInvoked)
                     {

--- a/SevenZip.Tests/SevenZipExtractorAsynchronousTests.cs
+++ b/SevenZip.Tests/SevenZipExtractorAsynchronousTests.cs
@@ -5,7 +5,7 @@
     using System.Threading.Tasks;
     using NUnit.Framework;
 
-    [TestFixture, Ignore("Flaky tests, need to be re-written to run consistently in AppVeyor.")]
+    [TestFixture]
     public class SevenZipExtractorAsynchronousTests : TestBase
     {
         [Test]
@@ -29,7 +29,7 @@
 
                 extractor.BeginExtractArchive(OutputDirectory);
 
-                var timeToWait = 1000;
+                var timeToWait = 2000;
                 while (extractionFinishedInvoked == 0)
                 {
                     if (timeToWait <= 0)

--- a/SevenZip.Tests/SevenZipExtractorAsynchronousTests.cs
+++ b/SevenZip.Tests/SevenZipExtractorAsynchronousTests.cs
@@ -79,7 +79,7 @@
                     extractor.ExtractionFinished += (o, e) => extractionFinishedInvoked = true;
                     extractor.BeginExtractFile(0, fileStream);
 
-                    var maximumTimeToWait = 2000;
+                    var maximumTimeToWait = 1000;
 
                     while (!extractionFinishedInvoked)
                     {

--- a/SevenZip/SevenZipBase.cs
+++ b/SevenZip/SevenZipBase.cs
@@ -207,6 +207,9 @@ namespace SevenZip
                             case -2147024891:
                                 exception = new SevenZipException("Access is denied. (0x80070005: E_ACCESSDENIED)");
                                 break;
+                            case -2146233086:
+                                exception = new SevenZipException("Argument is out of range. (0x80131502: E_ARGUMENTOUTOFRANGE)");
+                                break;
                             default:
                                 exception = new SevenZipException(
                                     $"Execution has failed due to an internal SevenZipSharp issue (0x{hresult:x} / {hresult}).\n" +

--- a/SevenZip/SevenZipExtractorAsynchronous.cs
+++ b/SevenZip/SevenZipExtractorAsynchronous.cs
@@ -13,32 +13,31 @@ namespace SevenZip
         /// </summary>
         private void RecreateInstanceIfNeeded()
         {
-            if (!NeedsToBeRecreated)
+            if (NeedsToBeRecreated)
             {
-                return;
-            }
-            
-            Stream backupStream = null;
-            string backupFileName = null;
-                
-            if (string.IsNullOrEmpty(_fileName))
-            {
-                backupStream = _inStream;
-            }
-            else
-            {
-                backupFileName = _fileName;
-            }
+                NeedsToBeRecreated = false;
+                Stream backupStream = null;
+                string backupFileName = null;
 
-            CommonDispose();
+                if (string.IsNullOrEmpty(_fileName))
+                {
+                    backupStream = _inStream;
+                }
+                else
+                {
+                    backupFileName = _fileName;
+                }
 
-            if (backupStream == null)
-            {
-                Init(backupFileName);
-            }
-            else
-            {
-                Init(backupStream);
+                CommonDispose();
+
+                if (backupStream == null)
+                {
+                    Init(backupFileName);
+                }
+                else
+                {
+                    Init(backupStream);
+                }
             }
         }
 


### PR DESCRIPTION
This should fix #188 , which was introduced in 1.6.0 due to following a ReSharper suggestion (and having unit tests ignored for this particular class).

I've re-enabled the tests, hopefully it will work on GitHub Actions 🙏