### PR TITLE
Use a wider check position so SFX archives are correctly detected.

### DIFF
--- a/SevenZip/SevenZipExtractor.cs
+++ b/SevenZip/SevenZipExtractor.cs
@@ -454,7 +454,7 @@ namespace SevenZip
         /// <returns>OperationResult.Ok if Open() succeeds.</returns>
         private OperationResult OpenArchiveInner(IInStream archiveStream, IArchiveOpenCallback openCallback)
         {
-            ulong checkPos = 1 << 15;
+            ulong checkPos = 1 << 23;
             var res = _archive.Open(archiveStream, ref checkPos, openCallback);
 
             return (OperationResult)res;


### PR DESCRIPTION
Hi again,

As per the 7-Zip source code, a wider maxCheckPos should be used to ensure that SFX archives can be extracted when explicitly specifying the archive format. Using the current `1 << 15` setting for example would not allow me to extract the NVIDIA drivers which are a self-extracting 7-Zip archive.

You may also see `1 << 23` used in the 7-Zip source code itself below at https://github.com/mcmilk/7-Zip/blob/e87b0c0e43231bef1007d421296aa54eaf8d70b0/CPP/7zip/UI/Client7z/Client7z.cpp#L1072-L1073

I have verified that updating this setting resolves the problem I was facing too.

Cheers
Fotis